### PR TITLE
Update citation information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+message: "If you write a scientific paper describing research that makes substantive use of UVaTRMM , we would appreciate that you cite the following paper:"
+authors:
+- given-names: 'Inmaculada'
+  family-names: 'Santamaria-Valenzuela'
+  orcid: 'https://orcid.org/0000-0002-7497-8795'
+- given-names: 'Rocío'
+  family-names: 'Carratalá-Sáez'
+  orcid: 'https://orcid.org/0000-0001-8409-2421'
+- given-names: 'Yuri'
+  family-names: 'Torres'
+  orcid: 'https://orcid.org/0000-0002-3037-3567'
+- given-names: 'Diego R.'
+  family-names: 'Llanos'
+  orcid: 'https://orcid.org/0000-0001-6240-9109'
+- given-names: 'Arturo'
+  family-names: 'Gonzalez-Escribano'
+  orcid: 'https://orcid.org/0000-0003-1309-9321'
+title: "Performance improvement of the triangular matrix product in commodity clusters"
+url: 'https://github.com/uva-trasgo/UVaTRMM'
+preferred-citation:
+  type: article
+  authors:
+  - given-names: 'Inmaculada'
+    family-names: 'Santamaria-Valenzuela'
+    orcid: 'https://orcid.org/0000-0002-7497-8795'
+  - given-names: 'Rocío'
+    family-names: 'Carratalá-Sáez'
+    orcid: 'https://orcid.org/0000-0001-8409-2421'
+  - given-names: 'Yuri'
+    family-names: 'Torres'
+    orcid: 'https://orcid.org/0000-0002-3037-3567'
+  - given-names: 'Diego R.'
+    family-names: 'Llanos'
+    orcid: 'https://orcid.org/0000-0001-6240-9109'
+  - given-names: 'Arturo'
+    family-names: 'Gonzalez-Escribano'
+    orcid: 'https://orcid.org/0000-0003-1309-9321'
+  doi: '10.1007/s11227-024-06097-7'
+  journal: "The Journal of Supercomputing"
+  month: 4
+  title: "Performance improvement of the triangular matrix product in commodity clusters"
+  year: 2024
+  issn: "1573-0484"
+

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ If you write a scientific paper describing research that makes substantive use o
 ```BibTeX
 	@Article{Carratala2023:UVaTRMM,
 	author = "Santamaria-Valenzuela, Inmaculada and Carratal{\'a}-S{\'a}ez, Roc{\'i}o and Torres, Yuri and Llanos, Diego R. and Gonzalez-Escribano, Arturo",
-	title="On the improvement of the triangular matrix product in commodity clusters",
+	title="Performance improvement of the triangular matrix product in commodity clusters",
 	journal="The Journal of Supercomputing",
-	year="To appear (submitted in Sept. 2023)",
+	year="2024",
 	issn="1573-0484",
-	doi="XXXX",
+	doi="https://doi.org/10.1007/s11227-024-06097-7",
 	}   
 ```


### PR DESCRIPTION
This PR changes the citation information at the bottom of the README to be up to date with the recently-published article (https://link.springer.com/article/10.1007/s11227-024-06097-7), including:
- Title change
- Year of publishing
- DOI

It also adds the file `CITATION.CFF`, so that Github shows a "Cite this repository" button at the right side of the page. More information [here](https://github.blog/2021-08-19-enhanced-support-citations-github/) and [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

The "Cite this repository" button will show a BibTeX citation, similar (but not equal) to the one at the bottom of the README. Unfortunately, this BibTeX citation is generated automatically for the button, and a custom one cannot be set manually. The biggest difference between the "README" and "Cite this repository" citations is that the accents are not properly escaped in the "Cite this repository" one (i.e. Rocío's name is written `Carratalá-Sáez, Rocío` instead of `Carratal{\'a}-S{\'a}ez, Roc{\'i}o`), and there is nothing we can do about that. Nevertheless, in my opinion, having the button on the page is still beneficial.